### PR TITLE
Add postgresql-client to ruby container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/sshd:1": {},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "libpq-dev, libvips"
+			"packages": "libpq-dev, libvips, postgresql-client"
 		},
 		"ghcr.io/devcontainers/features/git:1": {
 			"version": "latest"


### PR DESCRIPTION
When config.active_record.schema_format = :sql, `pg_dump` is required within the ruby container.