### PR TITLE
Add dependabot configuration for devcontainer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "daily"
+      time: "18:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "daily"
+      time: "18:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds dependabot configuration to monitor Docker images and devcontainer features
- Checks for updates daily at 18:00 (Europe/Berlin)
- Covers Dockerfile, docker-compose.yml, and devcontainer.json dependencies